### PR TITLE
Provide a systemd unit file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ Known problems
 1. **Podcasts, Radios, etc. aren't supported.**  
     This is a limitation of the Spotify Web API. There's currently nothing I can do about it.
 
+Systemd
+--------
+To use SpotPRIS2 with systemd, the provided unit file (`contrib/spotpris2.service`) should be copied into `/usr/lib/systemd/user`.
+
 ****
 
 This project is not affiliated, associated, authorized, endorsed by, or in any way officially connected with Spotify AB, or any of its subsidiaries or its affiliates.
+
 

--- a/contrib/spotpris2.service
+++ b/contrib/spotpris2.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Control Spotify Connect devices using MPRIS2
+Documentation=https://github.com/freundTech/SpotPRIS2
+Requires=dbus.socket
+After=dbus.socket
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/spotpris2
+Restart=always
+RestartSec=12
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This is a systemd unit file to allow spotpris2 to be daemonized. I put it in a separate folder in the top-level because it's probably not relevant for people installing out of PyPI, but for the AUR it probably make sense.