### PR TITLE
Ensure the timout_hander always returns True so it doesn't get destroyed

### DIFF
--- a/spotpris2/__main__.py
+++ b/spotpris2/__main__.py
@@ -70,8 +70,12 @@ def main():
             manager = SingleBusManager(sp)
 
     def timeout_handler():
-        manager.main_loop()
-        return True
+        try:
+            manager.main_loop()
+        except Exception as e:
+            print(e)
+        finally:
+            return True
 
     GLib.timeout_add_seconds(1, timeout_handler)
 


### PR DESCRIPTION
Fixes #8. But it also reduces the error logging of those timeout events. If you care, you can improve upon the simple `print(e)` business. Thanks for this project!